### PR TITLE
bump common dependency to 0.2.1

### DIFF
--- a/changelogs/0.4.0.md
+++ b/changelogs/0.4.0.md
@@ -1,6 +1,6 @@
 # 0.4.0
 
-- Depends on `wireleap/common` v0.2.0.
+- Depends on `wireleap/common` v0.2.1.
 - Uses new `version` command code.
 
 - Uses new interfaces versioning:

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/wireleap/common v0.2.0
+	github.com/wireleap/common v0.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/wireleap/common v0.2.0 h1:qsVXxnPm6oc9H0ztywNfV3eVT0JfNIerPNW+TSKH/LM=
-github.com/wireleap/common v0.2.0/go.mod h1:fkkbj+/ivixHoxo/Bie5JrS5eaSfCXGqvdXfWvd6PnA=
+github.com/wireleap/common v0.2.1 h1:F+iESNqkyBXtc8K+HRVc1+XAvdzbuoJNnq6Zf1a0UY0=
+github.com/wireleap/common v0.2.1/go.mod h1:fkkbj+/ivixHoxo/Bie5JrS5eaSfCXGqvdXfWvd6PnA=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a h1:kr2P4QFmQr29mSLA43kwrOcgcReGTfbE9N577tCTuBc=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=


### PR DESCRIPTION
avoids issues with the golang checksum cache